### PR TITLE
Crude VCs - ID fix, add "name" and "description"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@
 
 ## Hypothetical Crude Verifiable Credentials
 
-- [Crude Product](./crude/v1.0/crude-product-verifiable-credential-v1.0.json)
-- [Crude Product Inspection](./crude/v1.0/crude-inspection-verifiable-credential-v1.0.json)
-- [Bill of Lading](./crude/v1.0/bill-of-lading-verifiable-credential-v1.0.json)
-- [QP InBond](./crude/v1.0/qp-inbond-verifiable-credential-v1.0.json)
+- [Crude Product](./crude/examples/v1.0/crude-product-verifiable-credential-v1.0.json)
+- [Crude Product Inspection](./crude/examples/v1.0/crude-inspection-verifiable-credential-v1.0.json)
+- [Bill of Lading](./crude/examples/v1.0/bill-of-lading-verifiable-credential-v1.0.json)
+- [QP InBond](./crude/examples/v1.0/qp-inbond-verifiable-credential-v1.0.json)

--- a/docs/crude/examples/v1.0/bill-of-lading-verifiable-credential-v1.0.json
+++ b/docs/crude/examples/v1.0/bill-of-lading-verifiable-credential-v1.0.json
@@ -4,15 +4,17 @@
         "https://schema.org/",
         "https://mavennet.github.io/contexts/bill-of-lading-v1.0.jsonld"
     ],
-    "id": "dd0fbb48-7071-11ea-bc55-0242ac130003",
+    "id": "http://neo-flow.com/credentials/e94a16cb-35b2-4301-9fb6-7af3d8fe7b81",
     "type": [
         "VerifiableCredential",
         "BillOfLadingCredential"
     ],
+    "name": "Bill of Lading",
+    "description": "Detailed shipment document provided by the carrier to the receiver of products.",
     "issuer": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
-    "issuanceDate": "2020-03-31T21:14:15Z",
+    "issuanceDate": "2020-04-09T21:13:13Z",
     "credentialSubject": {
-        "productIdentifier": "dd0fbb48-7071-11ea-bc55-0242ac130003",
+        "productIdentifier": "3a185b8f-078a-4646-8343-76a45c2856a5",
         "bolNumber": "BOL000104976",
         "carrier": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
         "recipient": "did:v1:test:nym:z6MknQLHcwKwopce5ji1Ftsurn8mNL58wTxZB238uEMsegUj",
@@ -30,13 +32,13 @@
         "valuePerItem": "46",
         "totalOrderValue": "126500",
         "freightChargeTerms": "Freight Prepaid",
-        "expectedDeliveryDates": "30-MAR-2020",
+        "expectedDeliveryDates": "12-APR-2020",
         "comments": ""
     },
     "proof": {
         "type": "Ed25519Signature2018",
-        "created": "2020-03-31T21:14:28Z",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..hLWKPmnqWOK7BXzE0KJwBVcQt7g_W5ey47tqsys7fs8pZq-9YERf-k9v55GW-MozEu9g3FiBZ9b2L8tGCeYnBg",
+        "created": "2020-04-09T21:13:28Z",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..LKPyEKPPv3Q4cps3BB9nWWvQ_H8UfdtLezPvB1GXQwui1ONJJX3-W9yKpkBH6JUCcISITgIsSRRcCUEdTrleAw",
         "proofPurpose": "assertionMethod",
         "verificationMethod": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k#z6MkiukuAuQAE8ozxvmahnQGzApvtW7KT5XXKfojjwbdEomY"
     }

--- a/docs/crude/examples/v1.0/crude-inspection-verifiable-credential-v1.0.json
+++ b/docs/crude/examples/v1.0/crude-inspection-verifiable-credential-v1.0.json
@@ -4,21 +4,23 @@
         "https://schema.org/",
         "https://mavennet.github.io/contexts/crude-inspection-v1.0.jsonld"
     ],
-    "id": "dd0fbb48-7071-11ea-bc55-0242ac130003",
+    "id": "http://neo-flow.com/credentials/dd0fbb48-7071-11ea-bc55-0242ac130003",
     "type": [
         "VerifiableCredential",
         "CrudeInspectionCredential"
     ],
+    "name": "Heavy Sour Dilbit Inspection Report",
+    "description": "Inspection details of Heavy Sour Dilbit.",
     "issuer": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
-    "issuanceDate": "2020-03-31T21:12:57Z",
+    "issuanceDate": "2020-04-09T21:12:48Z",
     "credentialSubject": {
         "producer": "did:v1:test:nym:z6MkfG5HTrBXzsAP8AbayNpG3ZaoyM4PCqNPrdWQRSpHDV6J",
         "certifier": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
         "category": "Western Canadian Select",
         "hsCode": "270900",
-        "identifier": "dd0fbb48-7071-11ea-bc55-0242ac130003",
-        "name": "Heavy Sour Dilbit",
-        "description": "",
+        "identifier": "3a185b8f-078a-4646-8343-76a45c2856a5",
+        "name": "Heavy Sour Dilbit Inspection Report",
+        "description": "Inspection details of Heavy Sour Dilbit",
         "volume": "10000",
         "address": {
             "address": "Edmonton, CAN",
@@ -97,8 +99,8 @@
     },
     "proof": {
         "type": "Ed25519Signature2018",
-        "created": "2020-03-31T21:13:20Z",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..6BkzHmFxpedy6QY27Qstg_jqhyAIH9ssMrsjlKDNr2-GHjViBO9Ss2ZK4cjw5jIfzZZoO7KTOPZvXq2uDtt3Dw",
+        "created": "2020-04-09T21:13:00Z",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ICpAlw1L0GaqtBmwgeyohBeJc5Y7b7NeQp6u7quck8fOb1m7aWiISBDg9kL5cXZdDwbfDvxxeEv2A-2xbzf_Bg",
         "proofPurpose": "assertionMethod",
         "verificationMethod": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k#z6MkiukuAuQAE8ozxvmahnQGzApvtW7KT5XXKfojjwbdEomY"
     }

--- a/docs/crude/examples/v1.0/crude-product-verifiable-credential-v1.0.json
+++ b/docs/crude/examples/v1.0/crude-product-verifiable-credential-v1.0.json
@@ -4,20 +4,22 @@
         "https://schema.org/",
         "https://mavennet.github.io/contexts/crude-product-v1.0.jsonld"
     ],
-    "id": "3a185b8f-078a-4646-8343-76a45c2856a5",
+    "id": "http://neo-flow.com/credentials/3a185b8f-078a-4646-8343-76a45c2856a5",
     "type": [
         "VerifiableCredential",
         "CrudeProductCredential"
     ],
+    "name": "Heavy Sour Dilbit",
+    "description": "Crude oil stream, produced from diluted bitumen.",
     "issuer": "did:v1:test:nym:z6MkmbrHuhkzwWYeJjkBhTYktabXR22ECzk1WrHJPW69EsJY",
-    "issuanceDate": "2020-03-31T21:10:12Z",
+    "issuanceDate": "2020-04-09T21:12:12Z",
     "credentialSubject": {
         "producer": "did:v1:test:nym:z6MkfG5HTrBXzsAP8AbayNpG3ZaoyM4PCqNPrdWQRSpHDV6J",
         "category": "Western Canadian Select",
         "hsCode": "270900",
         "identifier": "3a185b8f-078a-4646-8343-76a45c2856a5",
         "name": "Heavy Sour Dilbit",
-        "description": "",
+        "description": "Crude oil stream, produced from diluted bitumen.",
         "volume": "10000",
         "address": {
             "address": "Edmonton, CAN",
@@ -96,8 +98,8 @@
     },
     "proof": {
         "type": "Ed25519Signature2018",
-        "created": "2020-03-31T21:10:49Z",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..GkOBM_UChasniYVvRfWGFf0n3qfoLIyLq9kTiWh7xkTkW1YLtD5HvkA92b0C7tP_T_XsDpRBpfVyPrSfb2j3Cg",
+        "created": "2020-04-09T21:12:28Z",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..VOFp3CC42FvRBqpTNVABY0DX4TqmLrkjG20K0Zl0JtfOU28EcUkndTQm1n9NPDyh3r4XXw0l7i-hxlViCjkTCw",
         "proofPurpose": "assertionMethod",
         "verificationMethod": "did:v1:test:nym:z6MkmbrHuhkzwWYeJjkBhTYktabXR22ECzk1WrHJPW69EsJY#z6Mkmh3mQN5VNM6yXksw19kiBHLNud8vXSfHE84xtanMchbA"
     }

--- a/docs/crude/examples/v1.0/qp-inbond-verifiable-credential-v1.0.json
+++ b/docs/crude/examples/v1.0/qp-inbond-verifiable-credential-v1.0.json
@@ -4,15 +4,17 @@
         "https://schema.org/",
         "https://mavennet.github.io/contexts/qp-in-bond-v1.0.jsonld"
     ],
-    "id": "dd0fbb48-7071-11ea-bc55-0242ac130003",
+    "id": "http://neo-flow.com/credentials/3aee17e7-8c50-4551-a8b4-9bc129c106e8",
     "type": [
         "VerifiableCredential",
         "QPInbondCredential"
     ],
+    "name": "QP Inbond",
+    "description": "Permit document for import/export of shipments that have not been cleared by US Customs.",
     "issuer": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
-    "issuanceDate": "2020-03-31T21:15:02Z",
+    "issuanceDate": "2020-04-09T21:13:43Z",
     "credentialSubject": {
-        "productIdentifier": "dd0fbb48-7071-11ea-bc55-0242ac130003",
+        "productIdentifier": "3a185b8f-078a-4646-8343-76a45c2856a5",
         "inBondNumber": "123456789",
         "inBondType": "IT (61)",
         "portOfEntry": "Superior, WI, USA",
@@ -33,13 +35,13 @@
         "bolNumber": "BOL000104976",
         "valuePerItem": "46",
         "totalOrderValue": "126500",
-        "expectedDeliveryDates": "26-MAR-2020",
+        "expectedDeliveryDates": "12-APR-2020",
         "comments": ""
     },
     "proof": {
         "type": "Ed25519Signature2018",
-        "created": "2020-03-31T21:15:16Z",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..7GJ06BsrK50DxBOnuw-FK_Y7KzhReLbZ1uLCbxhz0hpvQxs8YRuHmPgF5GBskZyuPVnPgcmMkxh6MPBWQuosCw",
+        "created": "2020-04-09T21:13:55Z",
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..fO8cjS1k5RTCUjg1UunT2MsJtqd8qFPC51-tLCYpUFRShNdRjfXvUjGL5irHDzYAKANYc5e9BNvOMel22af6DA",
         "proofPurpose": "assertionMethod",
         "verificationMethod": "did:v1:test:nym:z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k#z6MkiukuAuQAE8ozxvmahnQGzApvtW7KT5XXKfojjwbdEomY"
     }


### PR DESCRIPTION
This fixes ID value to be a URI in all the crude VCs as per #27 and this also adds "name" and "description" in Crude VCs for wallets to read correctly as per issue no 22. 