### PR TITLE
Added cross vendor verification checks

### DIFF
--- a/plugfest-2020/plugfest-2020.spec.js
+++ b/plugfest-2020/plugfest-2020.spec.js
@@ -430,7 +430,7 @@ describe('Plugfest 2020', () => {
           // eslint-disable-next-line-max-len
           describe('14. The Verifier\'s Verify Credential HTTP API SHOULD verify all other teams credentials', () => {
             const endpoint = vendor.verify_credential_endpoint;
-            vendors.map(ven => {
+            vendors.filter(ven => ven.name !== vendor.name).map(ven => {
               it(`should verify ${ven.name}\'s credentials`, async () =>{
                 await Promise.all(ven.verifiable_credentials.map(async vc => {
                   const body = {

--- a/plugfest-2020/plugfest-2020.spec.js
+++ b/plugfest-2020/plugfest-2020.spec.js
@@ -426,6 +426,26 @@ describe('Plugfest 2020', () => {
               expect(res.body.checks).toEqual(['proof']);
             });
           });
+
+          // eslint-disable-next-line-max-len
+          describe('14. The Verifier\'s Verify Credential HTTP API SHOULD verify all other teams credentials', () => {
+            const endpoint = vendor.verify_credential_endpoint;
+            vendors.map(ven => {
+              it(`should verify ${ven.name}\'s credentials`, async () =>{
+                await Promise.all(ven.verifiable_credentials.map(async vc => {
+                  const body = {
+                    verifiableCredential: vc,
+                    options: {
+                      checks: ['proof']
+                    },
+                  };
+                  const res = await help.postJson(endpoint, body);
+                  expect(res.status).toBe(200);
+                  expect(res.body.checks).toEqual(['proof']);
+                }));
+              });
+            });
+          });
         });
 
         describe('Verify Presentation HTTP API', () => {


### PR DESCRIPTION
I added a test in the Verifier checks that pulls credentials from all vendors and verifies them with the current verify endpoint. I am not sure if we want to merge this before tomorrow, but if we want to check  how each API does at verifying all cohort credentials, it could be a nice way to do that.